### PR TITLE
add Отчет по тестированию и покрытию кода, новые тесты fix баги

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,34 +19,34 @@ services:
       timeout: 5s
       retries: 10
 
-#  app:
-#    build:
-#      context: .
-#      dockerfile: Dockerfile
-#    container_name: statflux-app
-#    restart: unless-stopped
-#    depends_on:
-#      db:
-#        condition: service_healthy
-#    environment:
-#      TELEGRAM_BOT_TOKEN: ${TELEGRAM_BOT_TOKEN:?TELEGRAM_BOT_TOKEN is required}
-#      TELEGRAM_BOT_WHITE_LIST: ${TELEGRAM_BOT_WHITE_LIST:-}
-#
-#      DB_URL: jdbc:postgresql://db:5432/${POSTGRES_DB:-statflux_db}
-#      DB_USER: ${POSTGRES_USER:-statflux}
-#      DB_PASSWORD: ${POSTGRES_PASSWORD}
-#
-#      YOUTUBE_API_KEY: ${YOUTUBE_API_KEY:?YOUTUBE_API_KEY is required}
-#
-#      VK_API_URL: ${VK_API_URL:?VK_API_URL is required}
-#      VK_API_TOKEN: ${VK_API_TOKEN:?VK_API_TOKEN is required}
-#      VK_API_VERSION: ${VK_API_VERSION:?VK_API_VERSION is required}
-#
-#      RUTUBE_API_URL: ${RUTUBE_API_URL:?RUTUBE_API_URL is required}
-#
-#      REFRESH_DELAY_MS: ${REFRESH_INTERVAL_SECONDS:-60000}
-#      PAGE_SIZE: ${PAGE_SIZE:-5}
-#      POOL_SIZE: ${POOL_SIZE:-5}
+  app:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: statflux-app
+    restart: unless-stopped
+    depends_on:
+      db:
+        condition: service_healthy
+    environment:
+      TELEGRAM_BOT_TOKEN: ${TELEGRAM_BOT_TOKEN:?TELEGRAM_BOT_TOKEN is required}
+      TELEGRAM_BOT_WHITE_LIST: ${TELEGRAM_BOT_WHITE_LIST:-}
+
+      DB_URL: jdbc:postgresql://db:5432/${POSTGRES_DB:-statflux_db}
+      DB_USER: ${POSTGRES_USER:-statflux}
+      DB_PASSWORD: ${POSTGRES_PASSWORD}
+
+      YOUTUBE_API_KEY: ${YOUTUBE_API_KEY:?YOUTUBE_API_KEY is required}
+
+      VK_API_URL: ${VK_API_URL:?VK_API_URL is required}
+      VK_API_TOKEN: ${VK_API_TOKEN:?VK_API_TOKEN is required}
+      VK_API_VERSION: ${VK_API_VERSION:?VK_API_VERSION is required}
+
+      RUTUBE_API_URL: ${RUTUBE_API_URL:?RUTUBE_API_URL is required}
+
+      REFRESH_DELAY_MS: ${REFRESH_INTERVAL_SECONDS:-60000}
+      PAGE_SIZE: ${PAGE_SIZE:-5}
+      POOL_SIZE: ${POOL_SIZE:-5}
 
 volumes:
   postgres_data:

--- a/pom.xml
+++ b/pom.xml
@@ -180,6 +180,49 @@
                 <version>3.5.5</version>
             </plugin>
             <plugin>
+                <!-- Генерация отчета и архивирование -->
+                <!-- mvn verify jacoco:report -DskipCheckstyle -->
+                <!-- zip -r jacoco-report.zip target/site/jacoco/ и открыть  target/site/jacoco/index.html-->
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>0.8.12</version>
+                <configuration>
+                    <excludes>
+                        <!-- Config/DI — ручная сборка зависимостей, не тестируется -->
+                        <exclude>com/rmrf/statflux/bot/infra/config/**</exclude>
+                        <exclude>com/rmrf/statflux/integration/config/**</exclude>
+                        <exclude>com/rmrf/statflux/service/config/**</exclude>
+                        <exclude>com/rmrf/statflux/repository/config/**</exclude>
+                        <exclude>com/rmrf/statflux/constructor/**</exclude>
+                        <exclude>com/rmrf/statflux/Main*</exclude>
+                        <!-- DTO/record — data-контейнеры без логики -->
+                        <exclude>com/rmrf/statflux/repository/dto/**</exclude>
+                        <exclude>com/rmrf/statflux/domain/dto/**</exclude>
+                        <exclude>com/rmrf/statflux/integration/youtube/dto/**</exclude>
+                        <exclude>com/rmrf/statflux/integration/rutube/dto/**</exclude>
+                        <!-- Исключения без логики -->
+                        <exclude>com/rmrf/statflux/repository/exception/**</exclude>
+                        <exclude>com/rmrf/statflux/domain/exceptions/**</exclude>
+                        <!-- Локализация — строки, не логика -->
+                        <exclude>com/rmrf/statflux/bot/infra/l10n/**</exclude>
+                        <!-- HTTP-обёртка, покрывается интеграционными тестами косвенно -->
+                        <exclude>com/rmrf/statflux/integration/utils/**</exclude>
+                        <!-- Загрузчик конфигов при старте -->
+                        <exclude>com/rmrf/statflux/common/**</exclude>
+                    </excludes>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>prepare-agent</id>
+                        <goals><goal>prepare-agent</goal></goals>
+                    </execution>
+                    <execution>
+                        <id>prepare-agent-integration</id>
+                        <goals><goal>prepare-agent-integration</goal></goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
                 <version>3.2.5</version>

--- a/src/main/java/com/rmrf/statflux/bot/infra/middleware/WhiteListMiddleware.java
+++ b/src/main/java/com/rmrf/statflux/bot/infra/middleware/WhiteListMiddleware.java
@@ -24,7 +24,7 @@ public class WhiteListMiddleware implements Chain.Node<TelegramBotContext> {
 
         log.debug("Filtering");
         String username = ctx.update().getMessage().getFrom().getUserName();
-        if (allowedUsernames.contains(username)) {
+        if (username != null && allowedUsernames.contains(username)) {
             log.info(String.format("User '%s' was verified successfully", username));
             next.accept(ctx);
         } else {

--- a/src/test/java/com/rmrf/statflux/bot/infra/middleware/UncaughtErrorMiddlewareTest.java
+++ b/src/test/java/com/rmrf/statflux/bot/infra/middleware/UncaughtErrorMiddlewareTest.java
@@ -1,0 +1,107 @@
+package com.rmrf.statflux.bot.infra.middleware;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import com.rmrf.statflux.bot.core.TelegramBotContext;
+import com.rmrf.statflux.bot.infra.l10n.Localization;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Consumer;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.telegram.telegrambots.meta.api.methods.send.SendMessage;
+import org.telegram.telegrambots.meta.api.objects.Update;
+import org.telegram.telegrambots.meta.api.objects.message.Message;
+import org.telegram.telegrambots.meta.exceptions.TelegramApiException;
+import org.telegram.telegrambots.meta.generics.TelegramClient;
+
+class UncaughtErrorMiddlewareTest {
+
+    private static final long CHAT_ID = 42L;
+    private static final int MESSAGE_ID = 7;
+    private static final String ERROR_TEXT = "Что-то пошло не так";
+
+    private TelegramClient client;
+    private UncaughtErrorMiddleware middleware;
+
+    @BeforeEach
+    void setUp() {
+        client = mock(TelegramClient.class);
+        Localization.Common l10n = new Localization.Common();
+        l10n.uncaughtError = ERROR_TEXT;
+        middleware = new UncaughtErrorMiddleware(l10n);
+    }
+
+    private TelegramBotContext ctxWithMessage() {
+        Update upd = mock(Update.class);
+        Message msg = mock(Message.class);
+        lenient().when(upd.hasMessage()).thenReturn(true);
+        lenient().when(upd.getMessage()).thenReturn(msg);
+        lenient().when(msg.getChatId()).thenReturn(CHAT_ID);
+        lenient().when(msg.getMessageId()).thenReturn(MESSAGE_ID);
+        return new TelegramBotContext(upd, client);
+    }
+
+    private TelegramBotContext ctxWithoutMessage() {
+        Update upd = mock(Update.class);
+        lenient().when(upd.hasMessage()).thenReturn(false);
+        return new TelegramBotContext(upd, client);
+    }
+
+    private static Consumer<TelegramBotContext> throwing(RuntimeException ex) {
+        return ctx -> { throw ex; };
+    }
+
+    @Test
+    void happy_path_does_not_send_error_message() throws TelegramApiException {
+        var nextCalled = new AtomicBoolean(false);
+        middleware.handle(ctxWithMessage(), ctx -> nextCalled.set(true));
+
+        assertThat(nextCalled).isTrue();
+        verify(client, never()).execute(any(SendMessage.class));
+    }
+
+    @Test
+    void exception_with_message_context_sends_error_reply() throws TelegramApiException {
+        middleware.handle(ctxWithMessage(), throwing(new RuntimeException("boom")));
+
+        ArgumentCaptor<SendMessage> captor = ArgumentCaptor.forClass(SendMessage.class);
+        verify(client).execute(captor.capture());
+        SendMessage sent = captor.getValue();
+        assertThat(sent.getChatId()).isEqualTo(String.valueOf(CHAT_ID));
+        assertThat(sent.getText()).isEqualTo(ERROR_TEXT);
+        assertThat(sent.getReplyParameters().getMessageId()).isEqualTo(MESSAGE_ID);
+    }
+
+    @Test
+    void exception_without_message_context_does_not_send_reply() throws TelegramApiException {
+        middleware.handle(ctxWithoutMessage(), throwing(new RuntimeException("boom")));
+
+        verify(client, never()).execute(any(SendMessage.class));
+    }
+
+    @Test
+    void telegram_api_failure_during_error_reply_is_swallowed() throws TelegramApiException {
+        doThrow(new TelegramApiException("API down")).when(client).execute(any(SendMessage.class));
+
+        // вторичная ошибка не должна прорасти наружу
+        assertThatNoException().isThrownBy(() ->
+            middleware.handle(ctxWithMessage(), throwing(new RuntimeException("original")))
+        );
+    }
+
+    @Test
+    void java_error_is_also_caught_because_middleware_catches_throwable() throws TelegramApiException {
+        // Error — не Exception, но Middleware ловит Throwable
+        middleware.handle(ctxWithMessage(), ctx -> { throw new OutOfMemoryError("test"); });
+
+        verify(client).execute(any(SendMessage.class));
+    }
+}

--- a/src/test/java/com/rmrf/statflux/bot/infra/middleware/WhiteListMiddlewareTest.java
+++ b/src/test/java/com/rmrf/statflux/bot/infra/middleware/WhiteListMiddlewareTest.java
@@ -1,0 +1,100 @@
+package com.rmrf.statflux.bot.infra.middleware;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+
+import com.rmrf.statflux.bot.core.TelegramBotContext;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Consumer;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.telegram.telegrambots.meta.api.objects.Update;
+import org.telegram.telegrambots.meta.api.objects.User;
+import org.telegram.telegrambots.meta.api.objects.message.Message;
+import org.telegram.telegrambots.meta.generics.TelegramClient;
+
+class WhiteListMiddlewareTest {
+
+    private static final String ALLOWED = "alice";
+
+    private TelegramClient client;
+    private WhiteListMiddleware middleware;
+
+    @BeforeEach
+    void setUp() {
+        client = mock(TelegramClient.class);
+        middleware = new WhiteListMiddleware(Set.of(ALLOWED));
+    }
+
+    private TelegramBotContext ctxWithMessage(String username) {
+        Update upd = mock(Update.class);
+        Message msg = mock(Message.class);
+        User user = mock(User.class);
+        lenient().when(upd.hasMessage()).thenReturn(true);
+        lenient().when(upd.getMessage()).thenReturn(msg);
+        lenient().when(msg.getFrom()).thenReturn(user);
+        lenient().when(user.getUserName()).thenReturn(username);
+        return new TelegramBotContext(upd, client);
+    }
+
+    private TelegramBotContext ctxWithoutMessage() {
+        Update upd = mock(Update.class);
+        lenient().when(upd.hasMessage()).thenReturn(false);
+        return new TelegramBotContext(upd, client);
+    }
+
+    private static AtomicBoolean nextSpy() {
+        return new AtomicBoolean(false);
+    }
+
+    private static Consumer<TelegramBotContext> nextOf(AtomicBoolean flag) {
+        return ctx -> flag.set(true);
+    }
+
+    @Test
+    void update_without_message_passes_through_without_checking_username() {
+        var nextCalled = nextSpy();
+        middleware.handle(ctxWithoutMessage(), nextOf(nextCalled));
+        assertThat(nextCalled).isTrue();
+    }
+
+    @Test
+    void allowed_user_passes_through_to_next() {
+        var nextCalled = nextSpy();
+        middleware.handle(ctxWithMessage(ALLOWED), nextOf(nextCalled));
+        assertThat(nextCalled).isTrue();
+    }
+
+    @Test
+    void unknown_user_is_blocked() {
+        var nextCalled = nextSpy();
+        middleware.handle(ctxWithMessage("eve"), nextOf(nextCalled));
+        assertThat(nextCalled).isFalse();
+    }
+
+    @Test
+    void user_without_telegram_username_is_blocked() {
+        // Telegram позволяет не устанавливать username — getFrom().getUserName() возвращает null
+        var nextCalled = nextSpy();
+        middleware.handle(ctxWithMessage(null), nextOf(nextCalled));
+        assertThat(nextCalled).isFalse();
+    }
+
+    @Test
+    void empty_whitelist_blocks_all_users() {
+        middleware = new WhiteListMiddleware(Set.of());
+        var nextCalled = nextSpy();
+        middleware.handle(ctxWithMessage(ALLOWED), nextOf(nextCalled));
+        assertThat(nextCalled).isFalse();
+    }
+
+    @Test
+    void whitelist_check_is_case_sensitive() {
+        // "Alice" != "alice" — регистр важен
+        var nextCalled = nextSpy();
+        middleware.handle(ctxWithMessage("Alice"), nextOf(nextCalled));
+        assertThat(nextCalled).isFalse();
+    }
+}

--- a/src/test/java/com/rmrf/statflux/repository/ConnectionPoolIT.java
+++ b/src/test/java/com/rmrf/statflux/repository/ConnectionPoolIT.java
@@ -20,15 +20,22 @@ import org.junit.jupiter.api.Test;
 @Slf4j
 public class ConnectionPoolIT extends AbstractIntegrationTest {
 
+    private DataSource dataSource;
     private LinkRepository linkRepository;
     private TransactionManager tx;
 
     @BeforeEach
     public void setup() {
         RepositoryConfig repositoryConfig = new RepositoryConfig();
+        dataSource = repositoryConfig.pooledDataSource();
         linkRepository = repositoryConfig.linkRepository();
-        tx = new TransactionManager(repositoryConfig.pooledDataSource());
+        tx = new TransactionManager(dataSource);
         tx.executeWithoutResult(() -> SqlScripts.run("schema.sql"));
+    }
+
+    @AfterEach
+    public void tearDown() {
+        dataSource.close();
     }
 
     @Test

--- a/src/test/java/com/rmrf/statflux/repository/FullFlowIT.java
+++ b/src/test/java/com/rmrf/statflux/repository/FullFlowIT.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.rmrf.statflux.AbstractIntegrationTest;
 import com.rmrf.statflux.repository.config.RepositoryConfig;
+import com.rmrf.statflux.repository.datasource.DataSource;
 import com.rmrf.statflux.repository.dto.LinkDto;
 import com.rmrf.statflux.repository.dto.PaginationStateDto;
 import com.rmrf.statflux.repository.transaction.TransactionManager;
@@ -15,13 +16,16 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 public class FullFlowIT extends AbstractIntegrationTest {
-    private final RepositoryConfig repositoryConfig = new RepositoryConfig();
-    private final TransactionManager tx = new TransactionManager(repositoryConfig.pooledDataSource());
+    private DataSource dataSource;
+    private TransactionManager tx;
     private LinkRepository linkRepository;
     private PaginationStateRepository paginationStateRepository;
 
     @BeforeEach
     public void setup() {
+        RepositoryConfig repositoryConfig = new RepositoryConfig();
+        dataSource = repositoryConfig.pooledDataSource();
+        tx = new TransactionManager(dataSource);
         linkRepository = repositoryConfig.linkRepository();
         paginationStateRepository = repositoryConfig.paginationStateRepository();
     }
@@ -30,6 +34,7 @@ public class FullFlowIT extends AbstractIntegrationTest {
     public void tearDown() {
         tx.executeWithoutResult(
             () -> Queries.update("TRUNCATE TABLE links, pagination_state RESTART IDENTITY CASCADE"));
+        dataSource.close();
     }
 
     @Test

--- a/src/test/java/com/rmrf/statflux/repository/LinkRepositoryIT.java
+++ b/src/test/java/com/rmrf/statflux/repository/LinkRepositoryIT.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.rmrf.statflux.AbstractIntegrationTest;
 import com.rmrf.statflux.repository.config.RepositoryConfig;
+import com.rmrf.statflux.repository.datasource.DataSource;
 import com.rmrf.statflux.repository.dto.LinkDto;
 import com.rmrf.statflux.repository.transaction.TransactionManager;
 import com.rmrf.statflux.repository.util.Queries;
@@ -15,12 +16,15 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 public class LinkRepositoryIT extends AbstractIntegrationTest {
-    private final RepositoryConfig repositoryConfig = new RepositoryConfig();
-    private final TransactionManager tx = new TransactionManager(repositoryConfig.pooledDataSource());
+    private DataSource dataSource;
+    private TransactionManager tx;
     private LinkRepository linkRepository;
 
     @BeforeEach
     public void setup() {
+        RepositoryConfig repositoryConfig = new RepositoryConfig();
+        dataSource = repositoryConfig.pooledDataSource();
+        tx = new TransactionManager(dataSource);
         linkRepository = repositoryConfig.linkRepository();
     }
 
@@ -28,6 +32,7 @@ public class LinkRepositoryIT extends AbstractIntegrationTest {
     public void tearDown() {
         tx.executeWithoutResult(
             () -> Queries.update("TRUNCATE TABLE links RESTART IDENTITY CASCADE"));
+        dataSource.close();
     }
 
     @Test

--- a/src/test/java/com/rmrf/statflux/repository/PaginationStateRepositoryIT.java
+++ b/src/test/java/com/rmrf/statflux/repository/PaginationStateRepositoryIT.java
@@ -9,17 +9,30 @@ import com.rmrf.statflux.repository.transaction.TransactionManager;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.temporal.ChronoUnit;
+import com.rmrf.statflux.repository.datasource.DataSource;
+import com.rmrf.statflux.repository.util.Queries;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 public class PaginationStateRepositoryIT extends AbstractIntegrationTest {
-    private final RepositoryConfig repositoryConfig = new RepositoryConfig();
-    private final TransactionManager tx = new TransactionManager(repositoryConfig.pooledDataSource());
+    private DataSource dataSource;
+    private TransactionManager tx;
     private PaginationStateRepository paginationStateRepository;
 
     @BeforeEach
     public void setup() {
+        RepositoryConfig repositoryConfig = new RepositoryConfig();
+        dataSource = repositoryConfig.pooledDataSource();
+        tx = new TransactionManager(dataSource);
         paginationStateRepository = repositoryConfig.paginationStateRepository();
+    }
+
+    @AfterEach
+    public void tearDown() {
+        tx.executeWithoutResult(
+            () -> Queries.update("TRUNCATE TABLE links, pagination_state RESTART IDENTITY CASCADE"));
+        dataSource.close();
     }
 
     @Test


### PR DESCRIPTION
  **fix: устранена утечка соединений в IT-тестах, раскомментирован app-сервис в compose, добавлены тесты и отчет** 
  
  тесты (LinkRepositoryIT, FullFlowIT, PaginationStateRepositoryIT, ConnectionPoolIT) падали с
  ошибкой FATAL: sorry, too many clients already.

  Причина: JUnit 5 по умолчанию создаёт новый экземпляр класса для каждого тест-метода. В этих
  классах PooledDataSource инициализировался как поле объекта - то есть пул из 5 соединений
  открывался при создании каждого экземпляра. @AfterEach пул не закрывал. Итого: 17 тест-методов ×
  5 соединений = 85 открытых соединений к PostgreSQL, лимит исчерпан.
  
  